### PR TITLE
fix : 리액트퀼 빌드 오류 수정

### DIFF
--- a/src/components/QuillEditor/index.tsx
+++ b/src/components/QuillEditor/index.tsx
@@ -1,23 +1,22 @@
-import dynamic from 'next/dynamic';
-import 'react-quill/dist/quill.snow.css';
-import { useMemo, useRef } from 'react';
-import { Quill } from 'react-quill';
-import './test.css';
-import { domTreeToJson } from '@/utils/domTreeToJson';
-import { applyCssClasses } from '@/utils/applyCssClasses';
-import { jsonToHtml } from '@/utils/jsonToHtml';
-
-// class 생성을 위해 임시로 만들어 두었습니다.
-let Block = Quill.import('blots/block/embed');
-class TestBlot extends Block {}
-TestBlot.blotName = 'test';
-TestBlot.tagName = 'p';
-TestBlot.className = 'test';
-Quill.register(TestBlot);
+import dynamic from "next/dynamic";
+import "react-quill/dist/quill.snow.css";
+import { useMemo, useRef } from "react";
+import "./test.css";
+import { domTreeToJson } from "@/utils/domTreeToJson";
+import { applyCssClasses } from "@/utils/applyCssClasses";
+import { jsonToHtml } from "@/utils/jsonToHtml";
 
 const ReactQuill = dynamic(
   async () => {
-    const { default: RQ } = await import('react-quill');
+    const { default: RQ } = await import("react-quill");
+
+    // class 생성을 위해 임시로 만들어 두었습니다.
+    let Block = RQ.Quill.import("blots/block/embed");
+    class TestBlot extends Block {}
+    TestBlot.blotName = "test";
+    TestBlot.tagName = "p";
+    TestBlot.className = "test";
+    RQ.Quill.register(TestBlot);
 
     return function comp({ forwardedRef, ...props }: any) {
       return <RQ ref={forwardedRef} {...props} />;
@@ -36,22 +35,22 @@ export default function TextEditor({ setHtml, html }: any) {
 
   let cssClasses: any = {
     color: {
-      red: 'test',
-      'rgb(200, 0, 0)': 'test2',
+      red: "test",
+      "rgb(200, 0, 0)": "test2",
     },
-    'background-color': {
-      red: 'test3',
-      'rgb(200, 0, 0)': 'test4',
+    "background-color": {
+      red: "test3",
+      "rgb(200, 0, 0)": "test4",
     },
     width: {
-      '200px': 'test5',
-      '50%': 'test6',
+      "200px": "test5",
+      "50%": "test6",
     },
   };
 
   const handleChange = (content: any, delta: any, source: any, editor: any) => {
     let domTree = new DOMParser();
-    let doc = domTree.parseFromString(editor.getHTML(), 'text/html');
+    let doc = domTree.parseFromString(editor.getHTML(), "text/html");
 
     let iterator = document.createNodeIterator(doc.body, NodeFilter.SHOW_ALL);
     let node;
@@ -73,12 +72,12 @@ export default function TextEditor({ setHtml, html }: any) {
 
   // 임시
   const imageHandler = () => {
-    const input = document.createElement('input');
-    input.setAttribute('type', 'file');
-    input.setAttribute('accept', 'image/*');
+    const input = document.createElement("input");
+    input.setAttribute("type", "file");
+    input.setAttribute("accept", "image/*");
     input.click();
 
-    input.addEventListener('change', async () => {
+    input.addEventListener("change", async () => {
       const file = input.files ? input.files[0] : null;
 
       try {
@@ -86,7 +85,7 @@ export default function TextEditor({ setHtml, html }: any) {
         const imgUrl = res.data.imgUrl;
         const editor = quillRef.current.getEditor();
         const range = editor.getSelection();
-        editor.insertEmbed(range.index, 'image', imgUrl);
+        editor.insertEmbed(range.index, "image", imgUrl);
         editor.setSelection(range.index + 1);
       } catch (error) {
         console.log(error);
@@ -98,24 +97,24 @@ export default function TextEditor({ setHtml, html }: any) {
     () => ({
       toolbar: {
         container: [
-          ['bold', 'italic', 'underline', 'strike'],
-          ['blockquote', 'code-block'],
+          ["bold", "italic", "underline", "strike"],
+          ["blockquote", "code-block"],
 
           [{ header: 1 }, { header: 2 }],
-          [{ list: 'ordered' }, { list: 'bullet' }],
-          [{ script: 'sub' }, { script: 'super' }],
-          [{ indent: '-1' }, { indent: '+1' }],
-          [{ direction: 'rtl' }],
+          [{ list: "ordered" }, { list: "bullet" }],
+          [{ script: "sub" }, { script: "super" }],
+          [{ indent: "-1" }, { indent: "+1" }],
+          [{ direction: "rtl" }],
 
-          [{ size: ['small', false, 'large', 'huge'] }],
+          [{ size: ["small", false, "large", "huge"] }],
           [{ header: [1, 2, 3, 4, 5, 6, false] }],
 
           [{ color: [] }, { background: [] }],
           [{ font: [] }],
           [{ align: [] }],
 
-          ['clean'],
-          ['link', 'image', 'video'],
+          ["clean"],
+          ["link", "image", "video"],
         ],
         handlers: {
           image: imageHandler,
@@ -126,25 +125,25 @@ export default function TextEditor({ setHtml, html }: any) {
   );
 
   const formats = [
-    'header',
-    'font',
-    'size',
-    'bold',
-    'italic',
-    'underline',
-    'align',
-    'strike',
-    'script',
-    'blockquote',
-    'background',
-    'list',
-    'bullet',
-    'indent',
-    'link',
-    'image',
-    'color',
-    'code-block',
-    'test',
+    "header",
+    "font",
+    "size",
+    "bold",
+    "italic",
+    "underline",
+    "align",
+    "strike",
+    "script",
+    "blockquote",
+    "background",
+    "list",
+    "bullet",
+    "indent",
+    "link",
+    "image",
+    "color",
+    "code-block",
+    "test",
   ];
 
   return (
@@ -158,8 +157,8 @@ export default function TextEditor({ setHtml, html }: any) {
         modules={modules}
         formats={formats}
         value={html}
-        placeholder={'후원받고자 하는 동물의 자세한 정보를 입력해주세요!'}
-        theme='snow'
+        placeholder={"후원받고자 하는 동물의 자세한 정보를 입력해주세요!"}
+        theme="snow"
       />
     </div>
   );


### PR DESCRIPTION
빌드 오류 수정 제안

- 리액트 퀼 클라이언트 사이드 컴포넌트 오류 수정
- 오류 내용
  ```terminal
  Generating static pages (0/21)  [    ]ReferenceError: document is not defined
  ...
  ...
  ...
  Export encountered errors on following paths:
        /dashboard/write-content/page: /dashboard/write-content
        /question/write-content/page: /question/write-content
  ```

- 원인 
  - `ReactQuill` 의 스테틱 클래스인 `Quill` 을 상속받은 객체를 정의하는 클래스가 `next/dynamic` 메서드외부에 존재하여 발생
  - NextJS 빌드 엔진에서 컴포넌트를 미리 HTML로 랜더링 함

- 발생 시점
  - `Quill` 객체 생성자 내부에서 `document`에 접근하며 오류 발생

- 해결
  - `Quill` 상속 클래스 및 ReactQuill에 등록(`import`)하는 코드를 `dynamic` 메서드 안쪽으로 이동하여 컴포넌트를 미리 빌드하는것을 방지하고, 클라이언트 사이드랜더링으로 전환.