### PR TITLE
[#13] 글 작성위한 api client 수정

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,24 +1,33 @@
-import { TutorDataTypes } from "@/typings/user";
-import apiClient from "@/utils/api-client";
+import { TutorDataTypes } from '@/typings/user';
+import apiClient, { apiClientWithInterceptor } from '@/utils/api-client';
 
 export const signupTutor = async (userParms: TutorDataTypes) => {
   return await apiClient
-    .post("/auth/user/tutor", userParms)
+    .post('/auth/user/tutor', userParms)
     .then((data) => data.data);
 };
 
 export const signupTutee = async (
-  userParms: Omit<TutorDataTypes, "subject">
+  userParms: Omit<TutorDataTypes, 'subject'>
 ) => {
   return await apiClient
-    .post("/auth/user/tutee", userParms)
+    .post('/auth/user/tutee', userParms)
     .then((data) => data.data);
 };
 
 export const signin = async (
-  userParms: Pick<TutorDataTypes, "email" | "pw">
+  userParms: Pick<TutorDataTypes, 'email' | 'pw'>
 ) => {
   return await apiClient
-    .post("/auth/login", userParms)
+    .post('/auth/login', userParms)
+    .then((data) => data.data);
+};
+
+export const writeContent = async (
+  path: string,
+  params: { title: string; content: Array<Object> }
+) => {
+  return await apiClientWithInterceptor
+    .post(path, params)
     .then((data) => data.data);
 };

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -50,7 +50,7 @@ export default function Dashboard() {
       <SearchForm />
       <div className='flex items-center border-b-4 border-gray-300 border-solid pb-1.5'>
         <DashboardNavBar navItem={sortNavigationItems} />
-        <Link href='/question/write-content'>
+        <Link href='/dashboard/write-content'>
           <Button title='글쓰기' type='button' />
         </Link>
       </div>

--- a/src/app/dashboard/write-content/page.tsx
+++ b/src/app/dashboard/write-content/page.tsx
@@ -6,39 +6,7 @@ import { useState } from 'react';
 
 export default function WriteContent() {
   const [html, setHtml] = useState('');
-  console.log('test');
-  const testApi = async () => {
-    const data = await writeContent('/free', {
-      title: '테스트',
-      content: [
-        {
-          type: 'p',
-          attributes: {},
-          children: [{ type: 'text', textContent: 'asdf' }],
-        },
-        {
-          type: 'p',
-          attributes: {},
-          children: [{ type: 'br', attributes: {}, children: [] }],
-        },
-        {
-          type: 'p',
-          attributes: {},
-          children: [
-            { type: 'text', textContent: 'asdf' },
-            {
-              type: 'span',
-              attributes: { style: 'color: rgb(230, 0, 0);' },
-              children: [{ type: 'text', textContent: 'test' }],
-            },
-          ],
-        },
-      ],
-    });
 
-    console.log(data);
-  };
-  testApi();
   return (
     <div>
       <QuestionWriting setHtml={setHtml} html={html} />

--- a/src/app/dashboard/write-content/page.tsx
+++ b/src/app/dashboard/write-content/page.tsx
@@ -1,11 +1,44 @@
 'use client';
 
+import { writeContent } from '@/api/auth';
 import QuestionWriting from '@/components/QuestionWriting';
 import { useState } from 'react';
 
 export default function WriteContent() {
   const [html, setHtml] = useState('');
+  console.log('test');
+  const testApi = async () => {
+    const data = await writeContent('/free', {
+      title: '테스트',
+      content: [
+        {
+          type: 'p',
+          attributes: {},
+          children: [{ type: 'text', textContent: 'asdf' }],
+        },
+        {
+          type: 'p',
+          attributes: {},
+          children: [{ type: 'br', attributes: {}, children: [] }],
+        },
+        {
+          type: 'p',
+          attributes: {},
+          children: [
+            { type: 'text', textContent: 'asdf' },
+            {
+              type: 'span',
+              attributes: { style: 'color: rgb(230, 0, 0);' },
+              children: [{ type: 'text', textContent: 'test' }],
+            },
+          ],
+        },
+      ],
+    });
 
+    console.log(data);
+  };
+  testApi();
   return (
     <div>
       <QuestionWriting setHtml={setHtml} html={html} />

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -1,12 +1,42 @@
-import axios from "axios";
+import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: "https://tutor-api.devple.net",
+  baseURL: 'https://tutor-api.devple.net',
   headers: {
-    "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "*",
-    Accept: "application/json;chartset=utf-8",
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    Accept: 'application/json;chartset=utf-8',
   },
 });
+
+export const apiClientWithInterceptor = axios.create({
+  baseURL: 'https://tutor-api.devple.net',
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json;charset=utf-8',
+  },
+});
+
+apiClientWithInterceptor.interceptors.request.use(
+  function (config) {
+    const accessTokenObj = JSON.parse(
+      localStorage.getItem('accessToken') || '{"accessToken": ""}'
+    );
+    const refreshTokenObj = {
+      refresh:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6OCwiZW1haWwiOiJ0ZXN0NEBnbWFpbC5jb20iLCJpYXQiOjE3MDYxMTk4NTYsImV4cCI6MTcwNzMyOTQ1Nn0.spDjZ9ELTtgO3WVLqxIu4zU3yFV34bofeWTDiw4iV3c',
+    };
+
+    const accessToken = accessTokenObj ? accessTokenObj.accessToken : '';
+    const refreshToken = refreshTokenObj ? refreshTokenObj.refresh : '';
+
+    config.headers['Authorization'] = `${accessToken}`; // 임시토큰 Bearer 로컬스토리지에 있습니다.
+    config.headers['Refresh'] = `${refreshToken}`;
+    return config;
+  },
+  function (error) {
+    return Promise.reject(error);
+  }
+);
 
 export default apiClient;


### PR DESCRIPTION
- 수현님 코드 스타일에 맞춰 글 작성 api (auth.ts -> writeContent) 생성 했습니다.
- 헤더 추가를위해 apiClientWithInterceptor.interceptors 임시로 생성하였고 하시려던 방식에 따라 수정할게요!
- 현재 로그인시 로컬스토리지나 스토어에 AccessToken와 Refresh가 들어가는게 아닌 임시로 저장소에  넣어진 상황이라 
    `const accessTokenObj = JSON.parse(
      localStorage.getItem('accessToken') || '{"accessToken": ""}'
    );`
  등의 코드를 짜두었습니다! 이것도 추후에 수정할게요!